### PR TITLE
Fix async shutdown for SkyKettle connection

### DIFF
--- a/custom_components/skykettle/__init__.py
+++ b/custom_components/skykettle/__init__.py
@@ -85,7 +85,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_unload(entry, component)
         )
     hass.data[DOMAIN][DATA_CANCEL]()
-    await hass.async_add_executor_job(hass.data[DOMAIN][entry.entry_id][DATA_CONNECTION].stop)
+    await hass.data[DOMAIN][entry.entry_id][DATA_CONNECTION].stop()
     hass.data[DOMAIN][entry.entry_id][DATA_CONNECTION] = None
     _LOGGER.debug("Entry unloaded")
     return True

--- a/custom_components/skykettle/config_flow.py
+++ b/custom_components/skykettle/config_flow.py
@@ -112,7 +112,7 @@ class SkyKettleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             
             connect_ok = kettle._last_connect_ok
             auth_ok = kettle._last_auth_ok
-            kettle.stop()
+            await kettle.stop()
         
             if not connect_ok:
                 errors["base"] = "cant_connect"

--- a/custom_components/skykettle/kettle_connection.py
+++ b/custom_components/skykettle/kettle_connection.py
@@ -308,10 +308,11 @@ class KettleConnection(SkyKettle):
     async def cancel_target(self):
         self._target_state = None
 
-    def stop(self):
+    async def stop(self):
         if self._disposed: return
-        self._disconnect()
         self._disposed = True
+        self._target_state = None
+        await self.disconnect()
         _LOGGER.info("Stopped.")
 
     @property


### PR DESCRIPTION
This fixes the integration shutdown path for `KettleConnection`.

`stop()` currently calls the async `_disconnect()` method without awaiting it, and the unload path runs `stop()` in an executor. As a result, the BLE disconnect coroutine is never actually awaited during config flow cleanup or entry unload.

This patch makes `stop()` async, awaits `disconnect()`, clears any pending target state during disposal, and updates both call sites to await `stop()` directly.